### PR TITLE
Setup authentication for e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           node-version: '19.x'
           cache: pnpm
+      - name: 'Create .env file'
+        run: echo "${{ secrets.ENV_FILE }}" > .env
       - run: pnpm install --frozen-lockfile
       - run: pnpm check
       - run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,6 @@ on:
 env:
   # we call `pnpm playwright install` instead
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
-  PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
-  PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PUBLIC_SUPABASE_ANON_KEY }}
-  SPOTIFY_USER: ${{ secrets.SPOTIFY_USER }}
-  SPOTIFY_PASSWORD: ${{ secrets.SPOTIFY_PASSWORD }}
 
 # cancel in-progress runs on new commits to same PR (gitub.event.number)
 concurrency:
@@ -36,18 +32,12 @@ jobs:
       - run: pnpm check
       - run: pnpm lint
   Tests:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18]
-        os: [ubuntu-latest]
-        e2e-browser: ['chromium', 'firefox', 'webkit']
-        include:
-          - node-version: 19
-            os: ubuntu-latest
-            e2e-browser: 'chromium'
+        node-version: [18, 19]
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
@@ -56,20 +46,16 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
+      - name: 'Create .env file'
+        run: echo "${{ secrets.ENV_FILE }}" > .env
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:unit
-      - run: pnpm playwright install chromium
-      - run: pnpm playwright install ${{ matrix.e2e-browser }}
-      - run: pnpm playwright install-deps
-      - run: pnpm test:browser --project=${{ matrix.e2e-browser }}
-      - name: Archive test results
-        if: failure()
-        shell: bash
-        run: find packages -type d -name test-results -not -empty | tar -czf test-results.tar.gz --files-from=-
+      - run: pnpm playwright install chromium --with-deps
+      - run: pnpm test:browser
       - name: Upload test results
         if: failure()
         uses: actions/upload-artifact@v3
         with:
           retention-days: 3
-          name: test-failure-${{ github.run_id }}-${{ matrix.os }}-${{ matrix.node-version }}-${{ matrix.e2e-browser }}
-          path: test-results.tar.gz
+          name: test-failure-${{ github.run_id }}-${{ matrix.node-version }}
+          path: playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vercel
-/tests/storageState.json
+/tests/storage-state.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,4 +13,4 @@ pnpm-lock.yaml
 package-lock.json
 yarn.lock
 
-/tests/storageState.json
+/tests/storage-state.json

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,29 +1,19 @@
 import dotenv from 'dotenv';
-import { type PlaywrightTestConfig, devices } from '@playwright/test';
+import { type PlaywrightTestConfig } from '@playwright/test';
 
-dotenv.config({ path: './tests/.env' });
+dotenv.config({ path: '.env' });
 
 const config: PlaywrightTestConfig = {
+	globalSetup: './tests/global-setup',
+	use: {
+		storageState: './tests/storage-state.json'
+	},
 	webServer: {
 		command: 'pnpm build && pnpm preview --port 5173',
 		port: 5173,
 		reuseExistingServer: !process.env.CI
 	},
-	testDir: 'tests',
-	projects: [
-		{
-			name: 'chromium',
-			use: { ...devices['Desktop Chrome'] }
-		},
-		{
-			name: 'firefox',
-			use: { ...devices['Desktop Firefox'] }
-		},
-		{
-			name: 'webkit',
-			use: { ...devices['Desktop Safari'] }
-		}
-	]
+	testDir: 'tests'
 };
 
 export default config;

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,12 +1,12 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('authentication with spotify', () => {
-	test.skip('login with spotify works', async ({ page }) => {
+	test('login works', async ({ page }) => {
 		await page.goto('/');
-		await expect(page.getByText(`Hi, ${process.env.SPOTIFY_USER}`)).toBeVisible();
+		await expect(page.getByText('Hi')).toBeVisible();
 	});
 
-	test.skip('logout works', async ({ page }) => {
+	test('logout works', async ({ page }) => {
 		await page.goto('/');
 		await page.getByRole('button', { name: 'Logout' }).click();
 		await expect(page.getByText('Continue with Spotify')).toBeVisible();

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,69 @@
+import { chromium } from '@playwright/test';
+import { createClient } from '@supabase/supabase-js';
+
+const global_setup = async () => {
+	const browser = await chromium.launch();
+	const page = await browser.newPage();
+
+	const { access_token, refresh_token } = await get_supabase_tokens();
+	const spotify_access_token = await get_spotify_access_token();
+
+	page.context().addCookies([
+		{
+			name: 'supabase-auth-token',
+			value: JSON.stringify([
+				access_token,
+				refresh_token,
+				spotify_access_token,
+				process.env.TEST_SPOTIFY_REFRESH_TOKEN
+			]),
+			path: '/',
+			domain: 'localhost'
+		}
+	]);
+	// save cookies to reuse across tests
+	await page.context().storageState({ path: './tests/storage-state.json' });
+	await browser.close();
+};
+
+const get_supabase_tokens = async () => {
+	const supabase = createClient(process.env.PUBLIC_SUPABASE_URL ?? '', process.env.PUBLIC_SUPABASE_ANON_KEY ?? '');
+
+	const { data, error } = await supabase.auth.signInWithPassword({
+		email: process.env.TEST_EMAIL ?? '',
+		password: process.env.TEST_PASSWORD ?? ''
+	});
+
+	if (error) {
+		throw error;
+	}
+
+	if (!data.session) {
+		throw new Error('No session returned from Supabase');
+	}
+
+	const { access_token, refresh_token } = data.session;
+
+	return { access_token, refresh_token };
+};
+
+const get_spotify_access_token = async () => {
+	const res = await fetch('https://accounts.spotify.com/api/token', {
+		method: 'POST',
+		headers: {
+			Authorization: `Basic ${Buffer.from(
+				`${process.env.SPOTIFY_CLIENT_ID}:${process.env.SPOTIFY_CLIENT_SECRET}`
+			).toString('base64')}`,
+			'Content-Type': 'application/x-www-form-urlencoded'
+		},
+		body: new URLSearchParams({
+			grant_type: 'refresh_token',
+			refresh_token: process.env.TEST_SPOTIFY_REFRESH_TOKEN ?? ''
+		})
+	});
+
+	const data = await res.json();
+	return data.access_token;
+};
+
+export default global_setup;


### PR DESCRIPTION
- Run e2e tests on chromium only (webkit & firefox seems overkill)
- Use one root `.env` file and paste the whole thing in one `ENV_FILE` variable in GitHub secrets to populate it in CI action
- Setup auth for e2e tests by logging in with user & password, then adding Spotify tokens to the cookie